### PR TITLE
Converts fields (schema and value) to Double given a field list

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -487,7 +487,6 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     private final int snapshotMaxThreads;
 
     public MongoDbConnectorConfig(Configuration config) {
-
         super(config, config.getString(LOGICAL_NAME), DEFAULT_SNAPSHOT_FETCH_SIZE);
 
         String snapshotModeValue = config.getString(MongoDbConnectorConfig.SNAPSHOT_MODE);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -487,6 +487,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     private final int snapshotMaxThreads;
 
     public MongoDbConnectorConfig(Configuration config) {
+
         super(config, config.getString(LOGICAL_NAME), DEFAULT_SNAPSHOT_FETCH_SIZE);
 
         String snapshotModeValue = config.getString(MongoDbConnectorConfig.SNAPSHOT_MODE);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
@@ -63,7 +63,7 @@ import io.debezium.util.Strings;
  */
 public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Transformation<R> {
 
-    private String addFieldsPrefix;
+    protected String addFieldsPrefix;
 
     public enum ArrayEncoding implements EnumeratedValue {
         ARRAY("array"),
@@ -115,10 +115,10 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
         }
     }
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExtractNewDocumentState.class);
-    private static final Pattern FIELD_SEPARATOR = Pattern.compile("\\.");
+    protected static final Logger LOGGER = LoggerFactory.getLogger(ExtractNewDocumentState.class);
+    protected static final Pattern FIELD_SEPARATOR = Pattern.compile("\\.");
 
-    private static final Field ARRAY_ENCODING = Field.create("array.encoding")
+    protected static final Field ARRAY_ENCODING = Field.create("array.encoding")
             .withDisplayName("Array encoding")
             .withEnum(ArrayEncoding.class, ArrayEncoding.ARRAY)
             .withWidth(ConfigDef.Width.SHORT)
@@ -127,7 +127,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
                     + "'array' is easier to consume but requires all elements in the array to be of the same type. "
                     + "Use 'document' if the arrays in data source mix different types together.");
 
-    private static final Field FLATTEN_STRUCT = Field.create("flatten.struct")
+    protected static final Field FLATTEN_STRUCT = Field.create("flatten.struct")
             .withDisplayName("Flatten struct")
             .withType(ConfigDef.Type.BOOLEAN)
             .withWidth(ConfigDef.Width.SHORT)
@@ -136,7 +136,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
             .withDescription("Flattening structs by concatenating the fields into plain properties, using a "
                     + "(configurable) delimiter.");
 
-    private static final Field DELIMITER = Field.create("flatten.struct.delimiter")
+    protected static final Field DELIMITER = Field.create("flatten.struct.delimiter")
             .withDisplayName("Delimiter for flattened struct")
             .withType(ConfigDef.Type.STRING)
             .withWidth(ConfigDef.Width.SHORT)
@@ -173,24 +173,24 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
                     + "Adds the operation type of the change event as a header."
                     + "Its key is '" + ExtractNewRecordStateConfigDefinition.DEBEZIUM_OPERATION_HEADER_KEY + "'");
 
-    private final ExtractField<R> afterExtractor = new ExtractField.Value<>();
-    private final ExtractField<R> patchExtractor = new ExtractField.Value<>();
-    private final ExtractField<R> keyExtractor = new ExtractField.Key<>();
+    protected final ExtractField<R> afterExtractor = new ExtractField.Value<>();
+    protected final ExtractField<R> patchExtractor = new ExtractField.Value<>();
+    protected final ExtractField<R> keyExtractor = new ExtractField.Key<>();
 
-    private MongoDataConverter converter;
-    private final Flatten<R> recordFlattener = new Flatten.Value<>();
+    protected MongoDataConverter converter;
+    protected final Flatten<R> recordFlattener = new Flatten.Value<>();
 
-    private boolean addOperationHeader;
-    private List<String> addSourceFields;
-    private List<FieldReference> additionalHeaders;
-    private List<FieldReference> additionalFields;
-    private boolean flattenStruct;
-    private String delimiter;
+    protected boolean addOperationHeader;
+    protected List<String> addSourceFields;
+    protected List<FieldReference> additionalHeaders;
+    protected List<FieldReference> additionalFields;
+    protected boolean flattenStruct;
+    protected String delimiter;
 
-    private boolean dropTombstones;
-    private DeleteHandling handleDeletes;
+    protected boolean dropTombstones;
+    protected DeleteHandling handleDeletes;
 
-    private SmtManager<R> smtManager;
+    protected SmtManager<R> smtManager;
 
     @Override
     public R apply(R record) {
@@ -265,7 +265,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
         return newRecord(record, keyDocument, valueDocument);
     }
 
-    private R newRecord(R record, BsonDocument keyDocument, BsonDocument valueDocument) {
+    protected R newRecord(R record, BsonDocument keyDocument, BsonDocument valueDocument) {
         SchemaBuilder keySchemaBuilder = SchemaBuilder.struct();
         Set<Entry<String, BsonValue>> keyPairs = keyDocument.entrySet();
         for (Entry<String, BsonValue> keyPairsForSchema : keyPairs) {
@@ -345,7 +345,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
         return newRecord;
     }
 
-    private void addSourceFieldsSchema(String fieldPrefix, List<String> addSourceFields, R originalRecord, SchemaBuilder valueSchemaBuilder) {
+    protected void addSourceFieldsSchema(String fieldPrefix, List<String> addSourceFields, R originalRecord, SchemaBuilder valueSchemaBuilder) {
         Schema sourceSchema = originalRecord.valueSchema().field("source").schema();
         for (String sourceField : addSourceFields) {
             if (sourceSchema.field(sourceField) == null) {
@@ -356,14 +356,14 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
         }
     }
 
-    private void addAdditionalFieldsSchema(List<FieldReference> additionalFields, R originalRecord, SchemaBuilder valueSchemaBuilder) {
+    protected void addAdditionalFieldsSchema(List<FieldReference> additionalFields, R originalRecord, SchemaBuilder valueSchemaBuilder) {
         Schema sourceSchema = originalRecord.valueSchema();
         for (FieldReference fieldReference : additionalFields) {
             valueSchemaBuilder.field(fieldReference.newFieldName, fieldReference.getSchema(sourceSchema));
         }
     }
 
-    private void addSourceFieldsValue(List<String> addSourceFields, R originalRecord, Struct valueStruct) {
+    protected void addSourceFieldsValue(List<String> addSourceFields, R originalRecord, Struct valueStruct) {
         Struct sourceValue = ((Struct) originalRecord.value()).getStruct("source");
         for (String sourceField : addSourceFields) {
             valueStruct.put(ExtractNewRecordStateConfigDefinition.METADATA_FIELD_PREFIX + sourceField,
@@ -371,7 +371,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
         }
     }
 
-    private void addFields(List<FieldReference> additionalFields, R originalRecord, Struct value) {
+    protected void addFields(List<FieldReference> additionalFields, R originalRecord, Struct value) {
         Struct originalRecordValue = (Struct) originalRecord.value();
 
         // Update the value with the new fields
@@ -380,7 +380,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
         }
     }
 
-    private BsonDocument getUpdateDocument(R patchRecord, BsonDocument keyDocument) {
+    protected BsonDocument getUpdateDocument(R patchRecord, BsonDocument keyDocument) {
         BsonDocument valueDocument = new BsonDocument();
         BsonDocument document = BsonDocument.parse(patchRecord.value().toString());
 
@@ -425,7 +425,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
         return valueDocument;
     }
 
-    private BsonDocument getInsertDocument(R record, BsonDocument key) {
+    protected BsonDocument getInsertDocument(R record, BsonDocument key) {
         BsonDocument valueDocument = BsonDocument.parse(record.value().toString());
         valueDocument.remove("_id");
         valueDocument.append("id", key.get("id"));
@@ -433,7 +433,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
         return valueDocument;
     }
 
-    private Headers makeHeaders(List<FieldReference> additionalHeaders, Struct originalRecordValue) {
+    protected Headers makeHeaders(List<FieldReference> additionalHeaders, Struct originalRecordValue) {
         Headers headers = new ConnectHeaders();
 
         for (FieldReference fieldReference : additionalHeaders) {
@@ -519,7 +519,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
         recordFlattener.configure(delegateConfig);
     }
 
-    private static List<String> determineAdditionalSourceField(String addSourceFieldsConfig) {
+    protected static List<String> determineAdditionalSourceField(String addSourceFieldsConfig) {
         if (Strings.isNullOrEmpty(addSourceFieldsConfig)) {
             return Collections.emptyList();
         }
@@ -530,7 +530,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
      * Represents a field that should be added to the outgoing record as a header attribute or struct field.
      */
     // todo: refactor with ExtractNewRecordState
-    private static class FieldReference {
+    protected static class FieldReference {
         /**
          * The struct ("source", "transaction") hosting the given field, or {@code null} for "op" and "ts_ms".
          */

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/HashExtractNewDocumentState.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/HashExtractNewDocumentState.java
@@ -25,13 +25,8 @@ import io.debezium.transforms.ExtractNewRecordStateConfigDefinition.DeleteHandli
 import io.debezium.transforms.SmtManager;
 
 /**
- * Debezium Mongo Connector generates the CDC records in String format. Sink connectors usually are not able to parse
- * the string and insert the document as it is represented in the Source. so a user use this SMT to parse the String
- * and insert the MongoDB document in the JSON format.
- *
- * @param <R> the subtype of {@link ConnectRecord} on which this transformation will operate
- * @author Sairam Polavarapu
- * @author Renato mefi
+ * Extends from ExtractNewDocumentState and adds schema and type casting from int to float given a field list in
+ * debezium.source.transforms.unwrap.field.tofloat.list conf in application.properties.
  */
 public class HashExtractNewDocumentState<R extends ConnectRecord<R>> extends ExtractNewDocumentState<R> {
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/HashExtractNewDocumentState.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/HashExtractNewDocumentState.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb.transforms;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Width;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.connector.mongodb.MongoDbFieldName;
+import io.debezium.data.Envelope.FieldName;
+import io.debezium.schema.FieldNameSelector;
+import io.debezium.transforms.ExtractNewRecordStateConfigDefinition;
+import io.debezium.transforms.ExtractNewRecordStateConfigDefinition.DeleteHandling;
+import io.debezium.transforms.SmtManager;
+
+/**
+ * Debezium Mongo Connector generates the CDC records in String format. Sink connectors usually are not able to parse
+ * the string and insert the document as it is represented in the Source. so a user use this SMT to parse the String
+ * and insert the MongoDB document in the JSON format.
+ *
+ * @param <R> the subtype of {@link ConnectRecord} on which this transformation will operate
+ * @author Sairam Polavarapu
+ * @author Renato mefi
+ */
+public class HashExtractNewDocumentState<R extends ConnectRecord<R>> extends ExtractNewDocumentState<R> {
+
+    public static final Field FIELD_TOFLOAT = Field.create("field.tofloat.list")
+            .withDisplayName("Convert Fields to Float")
+            .withType(Type.STRING)
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("A comma-separated list of fully-qualified names of fields that should be casted to float");
+
+    @Override
+    public ConfigDef config() {
+        final ConfigDef config = new ConfigDef();
+        Field.group(config, null,
+                ARRAY_ENCODING,
+                FLATTEN_STRUCT,
+                DELIMITER,
+                SANITIZE_FIELD_NAMES,
+                FIELD_TOFLOAT);
+        return config;
+    }
+
+    @Override
+    public void configure(final Map<String, ?> map) {
+        final Configuration config = Configuration.from(map);
+        smtManager = new SmtManager<>(config);
+
+        final Field.Set configFields = Field.setOf(ARRAY_ENCODING, FLATTEN_STRUCT, DELIMITER,
+                OPERATION_HEADER,
+                ADD_SOURCE_FIELDS,
+                ExtractNewRecordStateConfigDefinition.HANDLE_DELETES,
+                ExtractNewRecordStateConfigDefinition.DROP_TOMBSTONES,
+                ExtractNewRecordStateConfigDefinition.ADD_HEADERS,
+                ExtractNewRecordStateConfigDefinition.ADD_FIELDS,
+                SANITIZE_FIELD_NAMES,
+                FIELD_TOFLOAT);
+
+        if (!config.validateAndRecord(configFields, LOGGER::error)) {
+            throw new ConnectException("Unable to validate config.");
+        }
+
+        converter = new HashMongoDataConverter(
+                ArrayEncoding.parse(config.getString(ARRAY_ENCODING)),
+                FieldNameSelector.defaultNonRelationalSelector(config.getBoolean(SANITIZE_FIELD_NAMES)),
+                config.getString(FIELD_TOFLOAT).split(","),
+                config.getBoolean(SANITIZE_FIELD_NAMES));
+
+        addOperationHeader = config.getBoolean(OPERATION_HEADER);
+
+        addSourceFields = determineAdditionalSourceField(config.getString(ADD_SOURCE_FIELDS));
+
+        addFieldsPrefix = config.getString(ExtractNewRecordStateConfigDefinition.ADD_FIELDS_PREFIX);
+        String addHeadersPrefix = config.getString(ExtractNewRecordStateConfigDefinition.ADD_HEADERS_PREFIX);
+        additionalHeaders = FieldReference.fromConfiguration(addHeadersPrefix, config.getString(ExtractNewRecordStateConfigDefinition.ADD_HEADERS));
+        additionalFields = FieldReference.fromConfiguration(addFieldsPrefix, config.getString(ExtractNewRecordStateConfigDefinition.ADD_FIELDS));
+
+        flattenStruct = config.getBoolean(FLATTEN_STRUCT);
+        delimiter = config.getString(DELIMITER);
+
+        dropTombstones = config.getBoolean(ExtractNewRecordStateConfigDefinition.DROP_TOMBSTONES);
+        handleDeletes = DeleteHandling.parse(config.getString(ExtractNewRecordStateConfigDefinition.HANDLE_DELETES));
+
+        final Map<String, String> afterExtractorConfig = new HashMap<>();
+        afterExtractorConfig.put("field", FieldName.AFTER);
+        final Map<String, String> patchExtractorConfig = new HashMap<>();
+        patchExtractorConfig.put("field", MongoDbFieldName.PATCH);
+        final Map<String, String> keyExtractorConfig = new HashMap<>();
+        keyExtractorConfig.put("field", "id");
+
+        afterExtractor.configure(afterExtractorConfig);
+        patchExtractor.configure(patchExtractorConfig);
+        keyExtractor.configure(keyExtractorConfig);
+
+        final Map<String, String> delegateConfig = new HashMap<>();
+        delegateConfig.put("delimiter", delimiter);
+        recordFlattener.configure(delegateConfig);
+
+    }
+}

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/HashMongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/HashMongoDataConverter.java
@@ -22,10 +22,8 @@ import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.ArrayEnc
 import io.debezium.schema.FieldNameSelector.FieldNamer;
 
 /**
- * MongoDataConverter handles translating MongoDB strings to Kafka Connect schemas and row data to Kafka
- * Connect records.
- *
- * @author Sairam Polavarapu
+ * Extends from MongoDataConverter and adds schema and type casting from int to float given a field list in
+ * fieldsToFloat property.
  */
 public class HashMongoDataConverter extends MongoDataConverter {
 

--- a/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
+++ b/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
@@ -13,6 +13,4 @@ fi
 
 RUNNER=$(ls debezium-server-*runner.jar)
 
-export JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:8000
-export GOOGLE_APPLICATION_CREDENTIALS=conf/pubsub-publisher.json
 exec $JAVA_BINARY $DEBEZIUM_OPTS $JAVA_OPTS -cp "$RUNNER:conf:lib/*" io.debezium.server.Main

--- a/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
+++ b/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
@@ -13,4 +13,6 @@ fi
 
 RUNNER=$(ls debezium-server-*runner.jar)
 
+export JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:8000
+export GOOGLE_APPLICATION_CREDENTIALS=conf/pubsub-publisher.json
 exec $JAVA_BINARY $DEBEZIUM_OPTS $JAVA_OPTS -cp "$RUNNER:conf:lib/*" io.debezium.server.Main


### PR DESCRIPTION
O casting dos valores consiste em alterar o schema do registro bem como aplicar o casting no valor.

A implementação nova foi realizada nas classas `HashExtractNewDocumentState` e `HashMongoDataConverter` extendidas respectivamente de `ExtractNewDocumentState` e `MongoDataConverter`.

Utilização:

- Trocar a transform no `application.properties`:
```
 debezium.source.transforms.unwrap.type=io.debezium.connector.mongodb.transforms.HashExtractNewDocumentState
```
- Adicionar os campos que serão aplicados o casting no `application.properties` na configuração nova `debezium.source.transforms.unwrap.field.tofloat.list`:
```
debezium.source.transforms.unwrap.field.tofloat.list=hashlab.companies2.costs.mdrs.installments.fee,...
```
