### PR TITLE
Enabling content based routing

### DIFF
--- a/debezium-server/debezium-server-dist/pom.xml
+++ b/debezium-server/debezium-server-dist/pom.xml
@@ -14,6 +14,9 @@
     <properties>
         <assembly.descriptor>server-distribution</assembly.descriptor>
         <quarkus.package.type>legacy-jar</quarkus.package.type>
+        <!-- Scripting -->
+        <version.groovy>3.0.7</version.groovy>
+        <version.graalvm.js>20.0.0</version.graalvm.js>
     </properties>
 
     <dependencies>
@@ -91,6 +94,36 @@
                 <dependency>
                     <groupId>io.debezium</groupId>
                     <artifactId>debezium-server-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.debezium</groupId>
+                    <artifactId>debezium-scripting</artifactId>
+                </dependency>
+                <!-- Scripting -->
+                <dependency>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy</artifactId>
+                    <version>${version.groovy}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-json</artifactId>
+                    <version>${version.groovy}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-jsr223</artifactId>
+                    <version>${version.groovy}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.graalvm.js</groupId>
+                    <artifactId>js</artifactId>
+                    <version>${version.graalvm.js}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.graalvm.js</groupId>
+                    <artifactId>js-scriptengine</artifactId>
+                    <version>${version.graalvm.js}</version>
                 </dependency>
             </dependencies>
             <build>


### PR DESCRIPTION
Adicionando dependências para poder utilizar o io.debezium.transforms.ContentBasedRouter