### PR TITLE
Logging record when transformation fails

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/Transformations.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/Transformations.java
@@ -71,8 +71,18 @@ public class Transformations implements Closeable {
 
     public SourceRecord transform(SourceRecord record) {
         for (Transformation<SourceRecord> t : transforms) {
-            record = t.apply(record);
+            try {
+                record = t.apply(record);
+            } catch (Exception e) {
+                String recordStr = "null";
+                if (record != null) {
+                    recordStr = record.toString();
+                }
+                LOGGER.error("Error applying transformation on record: " + recordStr, e);
+                throw e;
+            }
             if (record == null) {
+                LOGGER.warn("Record null. Breaking transforms loop.");
                 break;
             }
         }


### PR DESCRIPTION
## Qual é o propósito do PR?
Quando uma tranformation falha, o debezium para o conector muitas vezes com mensagens de erro sem informação sobre o dado ou a collection.

Esta alteração loga o record que causou a exceção.

## Issues relacionados
[KIRBY-1392](https://hash-product.atlassian.net/browse/KIRBY-1392)